### PR TITLE
[DIGIT-12778] Update South African Validator

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -281,7 +281,7 @@ var iso3166_data = [
 	{alpha2: "WF", alpha3: "WLF", country_code: "681", country_name: "Wallis and Futuna", mobile_begin_with: [], phone_number_lengths: [6]},
 	{alpha2: "WS", alpha3: "WSM", country_code: "685", country_name: "Samoa", mobile_begin_with: ["7"], phone_number_lengths: [7]},
 	{alpha2: "YE", alpha3: "YEM", country_code: "967", country_name: "Yemen", mobile_begin_with: ["7"], phone_number_lengths: [9]},
-	{alpha2: "ZA", alpha3: "ZAF", country_code: "27", country_name: "South Africa", mobile_begin_with: ["6", "7", "8"], phone_number_lengths: [9]},
+	{alpha2: "ZA", alpha3: "ZAF", country_code: "27", country_name: "South Africa", mobile_begin_with: ["5", "6", "7", "8"], phone_number_lengths: [9]},
 	{alpha2: "ZM", alpha3: "ZMB", country_code: "260", country_name: "Zambia", mobile_begin_with: ["9"], phone_number_lengths: [9]},
 	{alpha2: "ZW", alpha3: "ZWE", country_code: "263", country_name: "Zimbabwe", mobile_begin_with: ["71", "73", "77"], phone_number_lengths: [9]}
 ];


### PR DESCRIPTION
https://digit.atlassian.net/browse/DIGIT-12778?atlOrigin=eyJpIjoiN2RhYTIxODBiODBmNDIyNGE1MDIwNTE3YjVkZTM4OGEiLCJwIjoiaiJ9

When I check the latest version of the original repository, this is indeed a valid area code now for South African numbers
https://github.com/AfterShip/phone/blob/master/src/data/country_phone_data.ts#L1868